### PR TITLE
ci: replace Cachix with the GitHub Actions cache

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,9 +10,9 @@ on:
     tags:
       - 'v*'
 
-# Requires repo secret CACHIX_AUTH_TOKEN (a write token for the "gdb-static"
-# Cachix cache). The first run populates the cache with the cross toolchains;
-# every later run fetches them instead of rebuilding gcc/musl from source.
+# No secrets required. The Nix store is restored from the GitHub Actions cache
+# populated by seed-cache.yaml on develop, so runners fetch the cross
+# toolchains instead of rebuilding gcc/musl from source.
 jobs:
   build:
     strategy:
@@ -33,10 +33,15 @@ jobs:
           experimental-features = nix-command flakes
           accept-flake-config = true
 
-    - uses: cachix/cachix-action@v15
+    # Restore only. seed-cache.yaml owns the writes: if all 12 matrix jobs
+    # saved their own ~1 GB store, one run would exhaust the 10 GB repo quota
+    # and evict the toolchains it just wrote. The prefix fallback keeps builds
+    # warm when flake.lock moves before the seed job has caught up.
+    - uses: nix-community/cache-nix-action@v7
       with:
-        name: gdb-static
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        primary-key: nix-${{ runner.os }}-${{ matrix.architecture }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-${{ matrix.architecture }}-
+        save: false
 
     - name: Build
       run: |

--- a/.github/workflows/seed-cache.yaml
+++ b/.github/workflows/seed-cache.yaml
@@ -1,0 +1,74 @@
+name: seed-nix-cache
+
+# Populates the GitHub Actions cache with the Nix store for every architecture,
+# so the PR pipeline restores prebuilt cross toolchains instead of compiling
+# gcc + musl from source. This replaces the Cachix substituter: no external
+# account, no secrets.
+#
+# Seeding runs on the default branch on purpose. A run may only restore caches
+# scoped to its own ref, its PR base branch, or the default branch — a cache
+# written from a topic branch would be invisible to every other PR.
+#
+# Only arm, powerpc, mips and mipsel really need this; x86_64 and aarch64 musl
+# toolchains are already on cache.nixos.org. They are seeded anyway so the
+# matrix stays uniform and a nixpkgs bump can't silently regress coverage.
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.gitmodules'
+      - '.github/workflows/seed-cache.yaml'
+  # GitHub evicts caches untouched for 7 days. Refresh before that happens.
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: seed-nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  seed:
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture: ["x86_64", "arm", "aarch64", "powerpc", "mips", "mipsel"]
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - uses: cachix/install-nix-action@v30
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+
+    # Restores first (a no-op on a cold cache), then saves the whole /nix store
+    # in the post-job phase. No `gc-max-store-size` here: the cross toolchain is
+    # a build-time dependency, so it is not reachable from the `result-*` gc
+    # roots and a store GC would delete exactly what we are trying to cache.
+    - uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ matrix.architecture }}-${{ hashFiles('flake.nix', 'flake.lock') }}
+        # Drop superseded generations so the 10 GB repo quota isn't spent on
+        # stale toolchains from older flake.lock revisions.
+        purge: true
+        purge-prefixes: nix-${{ runner.os }}-${{ matrix.architecture }}-
+        purge-created: 0
+        purge-primary-key: never
+
+    - name: Build
+      run: |
+        for build_type in slim full; do
+          nix build -L -o "result-$build_type" \
+            ".?submodules=1#gdb-static-${{ matrix.architecture }}-$build_type"
+
+          nix build -L -o "result-check-$build_type" \
+            ".?submodules=1#checks.x86_64-linux.gdb-static-${{ matrix.architecture }}-$build_type"
+        done

--- a/README.md
+++ b/README.md
@@ -127,12 +127,17 @@ nix flake check '.?submodules=1'
 Binary cache
 </summary> <br />
 
-The cross toolchains (gcc + musl per arch) are not in cache.nixos.org, so a
-cold build compiles them from source. CI and contributors fetch prebuilt
-toolchains from the project's [Cachix](https://cachix.org) cache instead — the
-substituter is declared in the flake's `nixConfig`, so `nix build` uses it
-automatically once you accept the flake config (`--accept-flake-config`, or add
-yourself to `trusted-users` in `nix.conf`).
+The `arm`, `powerpc`, `mips` and `mipsel` cross toolchains (gcc + musl) are not
+in cache.nixos.org, so a cold build compiles them from source. `x86_64` and
+`aarch64` are cached upstream and download as normal.
+
+CI avoids the rebuild with the GitHub Actions cache: `seed-cache.yaml` builds
+every architecture on `develop` and saves the Nix store per arch, and the PR
+pipeline restores it read-only. No account, no secrets, nothing to configure.
+
+That cache is internal to CI — there is no public substituter for this project,
+so a local first build of the exotic architectures does pay the toolchain cost
+once. It is then in your own `/nix/store` and never rebuilds.
 
 </details>
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,11 @@
 {
   description = "gdb-static — statically-linked, musl, cross-arch GDB builds (Nix port)";
 
-  # Pull prebuilt cross toolchains + artifacts from the project's Cachix cache so
-  # CI runners (and clones) fetch instead of rebuilding gcc/musl from source.
-  # See [[ci-cache-cachix]]. Seeded via `cachix watch-exec gdb-static -- nix build`.
-  nixConfig = {
-    extra-substituters = [ "https://gdb-static.cachix.org" ];
-    extra-trusted-public-keys = [
-      "gdb-static.cachix.org-1:p9zgCSvXoSJM6v5j6BGONQ2ZI+5Mx5s5Jd0gJz7iXn0="
-    ];
-  };
+  # No extra substituter is declared. CI restores the cross toolchains from the
+  # GitHub Actions cache (.github/workflows/seed-cache.yaml) rather than from a
+  # hosted binary cache, so there is nothing for a clone to opt into: a local
+  # cold build compiles gcc + musl for arm/powerpc/mips from source. x86_64 and
+  # aarch64 musl static toolchains come from cache.nixos.org as usual.
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";


### PR DESCRIPTION
Alternative to the Cachix setup in #8. Stacked on `feature/nix-flake-port`, so the diff here is only the cache swap.

## Why this is viable
Measured against the locked nixpkgs (`20535e48`), by querying `cache.nixos.org` for each `pkgsStatic` cross toolchain:

| arch | cache.nixos.org |
|---|---|
| x86_64 | CACHED |
| aarch64 | CACHED |
| arm | MISSING |
| powerpc | MISSING |
| mips (soft) | MISSING |
| mipsel (soft) | MISSING |

For aarch64 the full toolchain was verified, not just the gcc wrapper — unwrapped gcc, musl and binutils are all present. So only 4 of 6 architectures need caching at all. (mips *hard*-float is also missing, so the soft-float override is not the cause.)

The full closure is ~1.1 GB in Cachix today, comfortably inside the 10 GB GitHub Actions repo quota.

## Design
- **`seed-cache.yaml`** (new) — matrix over the 6 arches, builds slim + full + checks, saves `/nix` via `nix-community/cache-nix-action@v7`. Runs on push to `develop`, weekly (GitHub evicts caches idle for 7 days), and `workflow_dispatch`.
- **`pipeline.yaml`** — Cachix step replaced with the same action in `save: false` mode, plus a prefix fallback for when `flake.lock` moves ahead of the seed.

Two constraints drove the shape:

1. **Writes are confined to the seed workflow.** 12 matrix jobs each saving a ~1 GB store would exhaust the quota in one run and evict what they just wrote.
2. **Seeding runs on the default branch.** A run may only restore caches scoped to its own ref, its PR base branch, or the default branch — a cache written from a topic branch is invisible to every other PR.

Per-arch keys (rather than one shared cache) keep the seed matrix parallel; a single job building all 12 targets serially would risk the 6h runner limit.

No `gc-max-store-size`: the cross toolchain is a build-time dependency and is not reachable from the `result-*` gc roots, so a store GC would delete exactly what we are trying to cache. Stale generations are handled by `purge` instead.

## Trade-offs vs #8
- **Gains:** no external account, no `CACHIX_AUTH_TOKEN`, no 5 GB tier ceiling. Fork PRs work — they can read the base repo's default-branch cache without needing secrets.
- **Costs:** restore is a whole-store tarball, not fine-grained NAR substitution, so a job downloads the full ~1 GB even when it needs a fraction. Per-arch caches duplicate shared nixpkgs paths, so expect several GB of the 10 GB quota in use — worth watching after the first seed.
- **Regression:** no public substituter any more. A contributor's cold local build of arm/powerpc/mips compiles the toolchain from source once. Cachix gave that away for free; this does not.

## Unverified
The seed workflow cannot run until this lands on `develop` (it triggers on push to the default branch). Cache-hit behaviour and real cache sizes are therefore untested — `workflow_dispatch` is wired up so it can be triggered manually first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
